### PR TITLE
add supath import alias

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -33,5 +33,21 @@
         "no-console": [
             "error"
         ]
+    },
+    "settings": {
+        "import/resolver": {
+            "alias": {
+                "map": [
+                    ["#config", "./src/config"],
+                    ["#controllers", "./src/controllers"],
+                    ["#middleware", "./src/middleware"],
+                    ["#models", "./src/models"],
+                    ["#services", "./src/services"],
+                    ["#root", "./src/"],
+                    ["#server", "./src/server.js"]
+                ],
+                "extensions": [".js", ".jsx", ".json"]
+            }
+        }
     }
 }

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "es6",
+    "baseUrl": ".",
+    "paths": {
+      "#server": ["./src/server.js"],
+      "#config/*": ["./src/config/*"],
+      "#controllers/*": ["./src/controllers/*"],
+      "#middleware/*": ["./src/middleware/*"],
+      "#models/*": ["./src/models/*"],
+      "#services/*": ["./src/services/*"]
+    }
+  },
+  "exclude": ["node-modules"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-boilerplate",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-boilerplate",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.8.1",
@@ -25,14 +25,15 @@
         "passport-local": "^1.0.0",
         "pg": "^8.7.1",
         "pg-hstore": "^2.3.3",
-        "sequelize": "^5.21.3",
+        "sequelize": "^6.12.0-alpha.1",
         "sequelize-cli": "^6.3.0",
         "winston": "^3.3.3"
       },
       "devDependencies": {
         "eslint": "^6.8.0",
         "eslint-config-airbnb-base": "^14.1.0",
-        "eslint-plugin-import": "^2.20.2",
+        "eslint-import-resolver-alias": "^1.1.2",
+        "eslint-plugin-import": "^2.25.3",
         "eslint-plugin-security": "^1.4.0",
         "expect": "^24.9.0",
         "faker": "^4.1.0",
@@ -261,6 +262,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
+      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
@@ -291,6 +300,11 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
+    },
+    "node_modules/@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "node_modules/@types/node": {
       "version": "16.11.7",
@@ -1789,15 +1803,6 @@
         "mimic-response": "^1.0.0"
       }
     },
-    "node_modules/cls-bluebird": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cls-bluebird/-/cls-bluebird-2.1.0.tgz",
-      "integrity": "sha1-N+8eCAqP+1XC9BZPU28ZGeeWiu4=",
-      "dependencies": {
-        "is-bluebird": "^1.0.2",
-        "shimmer": "^1.1.0"
-      }
-    },
     "node_modules/code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -2498,6 +2503,18 @@
       "peerDependencies": {
         "eslint": "^5.16.0 || ^6.8.0 || ^7.2.0",
         "eslint-plugin-import": "^2.22.1"
+      }
+    },
+    "node_modules/eslint-import-resolver-alias": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-alias/-/eslint-import-resolver-alias-1.1.2.tgz",
+      "integrity": "sha512-WdviM1Eu834zsfjHtcGHtGfcu+F30Od3V7I9Fi57uhBEwPkjDcii7/yW8jAT+gOhn4P/vOxxNAXbFAKsrrc15w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      },
+      "peerDependencies": {
+        "eslint-plugin-import": ">=1.4.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {
@@ -3853,9 +3870,9 @@
       }
     },
     "node_modules/inflection": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.12.0.tgz",
-      "integrity": "sha1-ogCTVlbW9fa8TcdQLhrstwMihBY=",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.13.1.tgz",
+      "integrity": "sha512-dldYtl2WlN0QDkIDtg8+xFwOS2Tbmp12t1cHa5/YClU6ZQjTFm7B66UcVbh9NQB+HvT5BAd2t5+yKsBkw5pcqA==",
       "engines": [
         "node >= 0.4.0"
       ]
@@ -4062,14 +4079,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is-bluebird": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-bluebird/-/is-bluebird-1.0.2.tgz",
-      "integrity": "sha1-CWQ5Bg9KpBGr7hkUOoTWpVNG1uI=",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/is-boolean-object": {
@@ -6985,28 +6994,48 @@
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "node_modules/sequelize": {
-      "version": "5.22.4",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-5.22.4.tgz",
-      "integrity": "sha512-xFQQ38HPg7EyDRDA+NdzMSRWbo9m6Z/RxpjnkBl3ggyQG+jRrup48x0jaw4Ox42h56wFnXOBC2NZOkTJfZeWCw==",
+      "version": "6.12.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.12.0-alpha.1.tgz",
+      "integrity": "sha512-MrjM8GJtUKhuc3ZkGbhlSr1DQdce3oRAI4STwgurfO0utBcdQE0kC1O3hp752XRFwzM+brH9Oy/dbVkupIZ4BQ==",
       "dependencies": {
-        "bluebird": "^3.5.0",
-        "cls-bluebird": "^2.1.0",
+        "@types/debug": "^4.1.7",
         "debug": "^4.1.1",
         "dottie": "^2.0.0",
-        "inflection": "1.12.0",
-        "lodash": "^4.17.15",
-        "moment": "^2.24.0",
-        "moment-timezone": "^0.5.21",
+        "inflection": "1.13.1",
+        "lodash": "^4.17.20",
+        "moment": "^2.26.0",
+        "moment-timezone": "^0.5.31",
+        "pg-connection-string": "^2.5.0",
         "retry-as-promised": "^3.2.0",
-        "semver": "^6.3.0",
-        "sequelize-pool": "^2.3.0",
+        "semver": "^7.3.2",
+        "sequelize-pool": "^6.0.0",
         "toposort-class": "^1.0.1",
-        "uuid": "^3.3.3",
-        "validator": "^10.11.0",
-        "wkx": "^0.4.8"
+        "uuid": "^8.1.0",
+        "validator": "^13.7.0",
+        "wkx": "^0.5.0"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "mariadb": {
+          "optional": true
+        },
+        "mysql2": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "pg-hstore": {
+          "optional": true
+        },
+        "sqlite3": {
+          "optional": true
+        },
+        "tedious": {
+          "optional": true
+        }
       }
     },
     "node_modules/sequelize-cli": {
@@ -7208,11 +7237,11 @@
       }
     },
     "node_modules/sequelize-pool": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/sequelize-pool/-/sequelize-pool-2.3.0.tgz",
-      "integrity": "sha512-Ibz08vnXvkZ8LJTiUOxRcj1Ckdn7qafNZ2t59jYHMX1VIebTAOYefWdRYFt6z6+hy52WGthAHAoLc9hvk3onqA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/sequelize-pool/-/sequelize-pool-6.1.0.tgz",
+      "integrity": "sha512-4YwEw3ZgK/tY/so+GfnSgXkdwIJJ1I32uZJztIEgZeAO6HMgj64OzySbWLgxj+tXhZCJnzRfkY9gINw8Ft8ZMg==",
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/sequelize/node_modules/debug": {
@@ -7231,10 +7260,48 @@
         }
       }
     },
+    "node_modules/sequelize/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/sequelize/node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/sequelize/node_modules/semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sequelize/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/sequelize/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/serve-static": {
       "version": "1.14.1",
@@ -7316,11 +7383,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/shimmer": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
     },
     "node_modules/side-channel": {
       "version": "1.0.4",
@@ -8641,15 +8703,6 @@
         "node": ">= 0.4.0"
       }
     },
-    "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
-    },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
@@ -8657,9 +8710,9 @@
       "dev": true
     },
     "node_modules/validator": {
-      "version": "10.11.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-10.11.0.tgz",
-      "integrity": "sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw==",
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
       "engines": {
         "node": ">= 0.10"
       }
@@ -8808,9 +8861,9 @@
       }
     },
     "node_modules/wkx": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.4.8.tgz",
-      "integrity": "sha512-ikPXMM9IR/gy/LwiOSqWlSL3X/J5uk9EO2hHNRXS41eTLXaUFEVw9fn/593jW/tE5tedNg8YjT5HkCa4FqQZyQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.5.0.tgz",
+      "integrity": "sha512-Xng/d4Ichh8uN4l0FToV/258EjMGU9MGcA0HV2d9B/ZpZB3lqQm7nkOdZdm5GhKtLLhAE7PiVQwN4eN+2YJJUg==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -9282,6 +9335,14 @@
         "defer-to-connect": "^1.0.1"
       }
     },
+    "@types/debug": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
+      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+      "requires": {
+        "@types/ms": "*"
+      }
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
@@ -9312,6 +9373,11 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
+    },
+    "@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "@types/node": {
       "version": "16.11.7",
@@ -10580,15 +10646,6 @@
         "mimic-response": "^1.0.0"
       }
     },
-    "cls-bluebird": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cls-bluebird/-/cls-bluebird-2.1.0.tgz",
-      "integrity": "sha1-N+8eCAqP+1XC9BZPU28ZGeeWiu4=",
-      "requires": {
-        "is-bluebird": "^1.0.2",
-        "shimmer": "^1.1.0"
-      }
-    },
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -11253,6 +11310,13 @@
         "object.assign": "^4.1.2",
         "object.entries": "^1.1.2"
       }
+    },
+    "eslint-import-resolver-alias": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-alias/-/eslint-import-resolver-alias-1.1.2.tgz",
+      "integrity": "sha512-WdviM1Eu834zsfjHtcGHtGfcu+F30Od3V7I9Fi57uhBEwPkjDcii7/yW8jAT+gOhn4P/vOxxNAXbFAKsrrc15w==",
+      "dev": true,
+      "requires": {}
     },
     "eslint-import-resolver-node": {
       "version": "0.3.6",
@@ -12229,9 +12293,9 @@
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
     },
     "inflection": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.12.0.tgz",
-      "integrity": "sha1-ogCTVlbW9fa8TcdQLhrstwMihBY="
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.13.1.tgz",
+      "integrity": "sha512-dldYtl2WlN0QDkIDtg8+xFwOS2Tbmp12t1cHa5/YClU6ZQjTFm7B66UcVbh9NQB+HvT5BAd2t5+yKsBkw5pcqA=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -12393,11 +12457,6 @@
       "requires": {
         "binary-extensions": "^2.0.0"
       }
-    },
-    "is-bluebird": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-bluebird/-/is-bluebird-1.0.2.tgz",
-      "integrity": "sha1-CWQ5Bg9KpBGr7hkUOoTWpVNG1uI="
     },
     "is-boolean-object": {
       "version": "1.1.2",
@@ -14646,25 +14705,25 @@
       }
     },
     "sequelize": {
-      "version": "5.22.4",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-5.22.4.tgz",
-      "integrity": "sha512-xFQQ38HPg7EyDRDA+NdzMSRWbo9m6Z/RxpjnkBl3ggyQG+jRrup48x0jaw4Ox42h56wFnXOBC2NZOkTJfZeWCw==",
+      "version": "6.12.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.12.0-alpha.1.tgz",
+      "integrity": "sha512-MrjM8GJtUKhuc3ZkGbhlSr1DQdce3oRAI4STwgurfO0utBcdQE0kC1O3hp752XRFwzM+brH9Oy/dbVkupIZ4BQ==",
       "requires": {
-        "bluebird": "^3.5.0",
-        "cls-bluebird": "^2.1.0",
+        "@types/debug": "^4.1.7",
         "debug": "^4.1.1",
         "dottie": "^2.0.0",
-        "inflection": "1.12.0",
-        "lodash": "^4.17.15",
-        "moment": "^2.24.0",
-        "moment-timezone": "^0.5.21",
+        "inflection": "1.13.1",
+        "lodash": "^4.17.20",
+        "moment": "^2.26.0",
+        "moment-timezone": "^0.5.31",
+        "pg-connection-string": "^2.5.0",
         "retry-as-promised": "^3.2.0",
-        "semver": "^6.3.0",
-        "sequelize-pool": "^2.3.0",
+        "semver": "^7.3.2",
+        "sequelize-pool": "^6.0.0",
         "toposort-class": "^1.0.1",
-        "uuid": "^3.3.3",
-        "validator": "^10.11.0",
-        "wkx": "^0.4.8"
+        "uuid": "^8.1.0",
+        "validator": "^13.7.0",
+        "wkx": "^0.5.0"
       },
       "dependencies": {
         "debug": {
@@ -14675,10 +14734,36 @@
             "ms": "2.1.2"
           }
         },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
       }
     },
@@ -14828,9 +14913,9 @@
       }
     },
     "sequelize-pool": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/sequelize-pool/-/sequelize-pool-2.3.0.tgz",
-      "integrity": "sha512-Ibz08vnXvkZ8LJTiUOxRcj1Ckdn7qafNZ2t59jYHMX1VIebTAOYefWdRYFt6z6+hy52WGthAHAoLc9hvk3onqA=="
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/sequelize-pool/-/sequelize-pool-6.1.0.tgz",
+      "integrity": "sha512-4YwEw3ZgK/tY/so+GfnSgXkdwIJJ1I32uZJztIEgZeAO6HMgj64OzySbWLgxj+tXhZCJnzRfkY9gINw8Ft8ZMg=="
     },
     "serve-static": {
       "version": "1.14.1",
@@ -14896,11 +14981,6 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
-    },
-    "shimmer": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
     },
     "side-channel": {
       "version": "1.0.4",
@@ -15960,11 +16040,6 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
-    "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-    },
     "v8-compile-cache": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
@@ -15972,9 +16047,9 @@
       "dev": true
     },
     "validator": {
-      "version": "10.11.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-10.11.0.tgz",
-      "integrity": "sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw=="
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw=="
     },
     "vary": {
       "version": "1.1.2",
@@ -16091,9 +16166,9 @@
       }
     },
     "wkx": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.4.8.tgz",
-      "integrity": "sha512-ikPXMM9IR/gy/LwiOSqWlSL3X/J5uk9EO2hHNRXS41eTLXaUFEVw9fn/593jW/tE5tedNg8YjT5HkCa4FqQZyQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.5.0.tgz",
+      "integrity": "sha512-Xng/d4Ichh8uN4l0FToV/258EjMGU9MGcA0HV2d9B/ZpZB3lqQm7nkOdZdm5GhKtLLhAE7PiVQwN4eN+2YJJUg==",
       "requires": {
         "@types/node": "*"
       }

--- a/package.json
+++ b/package.json
@@ -43,19 +43,28 @@
     "passport-local": "^1.0.0",
     "pg": "^8.7.1",
     "pg-hstore": "^2.3.3",
-    "sequelize": "^5.21.3",
+    "sequelize": "^6.12.0-alpha.1",
     "sequelize-cli": "^6.3.0",
     "winston": "^3.3.3"
   },
   "devDependencies": {
     "eslint": "^6.8.0",
     "eslint-config-airbnb-base": "^14.1.0",
-    "eslint-plugin-import": "^2.20.2",
+    "eslint-import-resolver-alias": "^1.1.2",
+    "eslint-plugin-import": "^2.25.3",
     "eslint-plugin-security": "^1.4.0",
     "expect": "^24.9.0",
     "faker": "^4.1.0",
     "mocha": "^7.1.0",
     "pre-commit": "^1.2.2",
     "supertest": "^4.0.2"
+  },
+  "imports": {
+    "#server": "./src/server.js",
+    "#config/*": "./src/config/*",
+    "#controllers/*": "./src/controllers/*",
+    "#middleware/*": "./src/middleware/*",
+    "#models/*": "./src/models/*",
+    "#services/*": "./src/services/*"
   }
 }

--- a/src/bin/www
+++ b/src/bin/www
@@ -3,8 +3,9 @@
 import 'dotenv/config';
 import http from 'http';
 
-import app from '../server.js';
-import logger from '../services/logger.js';
+import logger from '#services/logger.js';
+
+import app from '#server';
 
 const port = process.env.PORT || 3000;
 

--- a/src/config/database.js
+++ b/src/config/database.js
@@ -1,6 +1,6 @@
 import 'dotenv/config';
 
-import logger from '../services/logger.js';
+import logger from '#services/logger.js';
 
 const configurations = {
   development: {

--- a/src/config/passport.js
+++ b/src/config/passport.js
@@ -2,7 +2,7 @@ import passport from 'passport';
 import LocalStrategy from 'passport-local';
 import { Strategy as JWTstrategy, ExtractJwt as ExtractJWT } from 'passport-jwt';
 
-import { User } from '../services/database.js';
+import { User } from '#services/database.js';
 
 passport.use(
   new LocalStrategy(

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import passport from 'passport';
 import jwt from 'jsonwebtoken';
 
-import { show } from '../services/renderers/userRenderer.js';
+import { show } from '#services/renderers/userRenderer.js';
 
 const router = Router();
 

--- a/src/controllers/usersController.js
+++ b/src/controllers/usersController.js
@@ -1,11 +1,11 @@
 import { Router } from 'express';
 import passport from 'passport';
 
-import { show } from '../services/renderers/userRenderer.js';
+import { show } from '#services/renderers/userRenderer.js';
+import { User } from '#services/database.js';
 
-import { User } from '../services/database.js';
+import validateInput from '#middleware/validateInput.js';
 import userIV from './input-validators/users_body.js';
-import validateInput from '../middleware/validateInput.js';
 
 const router = Router();
 

--- a/src/middleware/validateInput.js
+++ b/src/middleware/validateInput.js
@@ -1,6 +1,6 @@
 import Ajv from 'ajv';
 
-import logger from '../services/logger.js';
+import logger from '#services/logger.js';
 
 const validator = new Ajv({ allErrors: true, async: true });
 

--- a/src/server.js
+++ b/src/server.js
@@ -3,11 +3,10 @@ import cors from 'cors';
 import morgan from 'morgan';
 import passport from 'passport';
 
-import logger from './services/logger.js';
-import usersController from './controllers/usersController.js';
-import authController from './controllers/authController.js';
-
-import './config/passport.js';
+import logger from '#services/logger.js';
+import usersController from '#controllers/usersController.js';
+import authController from '#controllers/authController.js';
+import '#config/passport.js';
 
 const app = express();
 
@@ -30,6 +29,7 @@ app.use('/api/users', usersController);
 
 app.listen(process.env.APP_PORT, () => {
   logger.info(`Server running on port ${process.env.APP_PORT}`);
+  logger.info('AdminBro is running at /admin');
 });
 
 export default app;

--- a/src/services/database.js
+++ b/src/services/database.js
@@ -1,8 +1,8 @@
 import { Sequelize } from 'sequelize';
 
-import config from '../config/database.js';
+import config from '#config/database.js';
 
-import UserModel from '../models/user.js';
+import UserModel from '#models/user.js';
 
 const { DataTypes } = Sequelize;
 

--- a/src/test/controllers/authController.js
+++ b/src/test/controllers/authController.js
@@ -2,8 +2,8 @@ import supertest from 'supertest';
 import expect from 'expect';
 import faker from 'faker';
 
-import { User } from '../../services/database.js';
-import app from '../../server.js';
+import app from '#server';
+import { User } from '#services/database.js';
 
 const api = supertest(app);
 

--- a/src/test/controllers/usersController.js
+++ b/src/test/controllers/usersController.js
@@ -2,8 +2,8 @@ import supertest from 'supertest';
 import expect from 'expect';
 import faker from 'faker';
 
-import { User } from '../../services/database.js';
-import app from '../../server.js';
+import app from '#server';
+import { User } from '#services/database.js';
 
 const api = supertest(app);
 

--- a/src/test/models/user.js
+++ b/src/test/models/user.js
@@ -2,7 +2,7 @@ import { compare } from 'bcrypt';
 import expect from 'expect';
 import faker from 'faker';
 
-import { User } from '../../services/database.js';
+import { User } from '#services/database.js';
 
 describe('Tests User', () => {
   // Save correct data


### PR DESCRIPTION
For subpath imports to work, we need to add the new alias to `package.json` with a `#` symbol at the start of the alias and the route to the file or folder.
![image](https://user-images.githubusercontent.com/38544384/144291699-3df04647-1942-49ab-8a90-daeb62f606c5.png)

Also, you need to add the new import to `jsconfig.js` key `paths` so Intellisense works for it:
![image](https://user-images.githubusercontent.com/38544384/144291965-37991673-6fee-4fc4-a082-c72d4b75753a.png)

Last but not least, [eslint-plugin-import does not support this feature for now](https://sgithub.com/import-js/eslint-plugin-import/issues/1868), so we need to use the plugin [eslint-import-resolver-alias](https://github.com/johvin/eslint-import-resolver-alias).
![image](https://user-images.githubusercontent.com/38544384/144292268-7e6963d4-f0f2-4f8e-aba8-2a4da0cf45ef.png)
